### PR TITLE
Addresses pom.xml review comments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,11 +135,5 @@
             <version>1.19</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.jenkins.configuration-as-code</groupId>
-            <artifactId>configuration-as-code-support</artifactId>
-            <version>1.19</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.180</jenkins.version>
+        <jenkins.version>2.176.1</jenkins.version>
         <java.level>8</java.level>
         <argLine>-Xmx1024m</argLine>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>1.19</version>
+            <version>1.22</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.176.1</jenkins.version>
+        <jenkins.version>2.138.1</jenkins.version>
         <java.level>8</java.level>
         <argLine>-Xmx1024m</argLine>
     </properties>


### PR DESCRIPTION
Summary of this pull request:
- [Remove deprecated "configuration-as-code-support" dependency]
- [ Bumped to LTS 2.138.1, which is the oldest LTS I can produce a successful build with]
- [ Bumped JCasC to 1.22]

Passes unit tests and builds successfully on my local machine.

CC @martinda @casz