### PR TITLE
Added shouldSupportConfigurationAsCodeAgentProperty() assertions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/ewm/casc/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/casc/ConfigAsCodeTest.java
@@ -85,9 +85,12 @@ public class ConfigAsCodeTest {
 
     @Test
     public void shouldSupportConfigurationAsCodeAgentProperty() throws Exception {
-        Computer computer = j.getInstance().getComputer("");
+        Computer computer = j.getInstance().getComputer("static-agent");
         Node node = computer.getNode();
         List<NodeDiskPool> nodeDiskPools = node.getNodeProperties().get(ExternalWorkspaceProperty.class).getNodeDiskPools();
+        assertThat(nodeDiskPools.get(0).getDiskPoolRefId(), is("localhostdiskpool"));
+        assertThat(nodeDiskPools.get(0).getNodeDisks().get(0).getDiskRefId(), is("localdisk"));
+        assertThat(nodeDiskPools.get(0).getNodeDisks().get(0).getNodeMountPoint(), is("/tmp/localdisk"));
     }
 
     @Test


### PR DESCRIPTION
Aims to address the comment from @alexsomai from: https://github.com/jenkinsci/external-workspace-manager-plugin/pull/68#discussion_r303194489.

CC @imaffe @martinda